### PR TITLE
Correção do atributo name para publicação correta do pom

### DIFF
--- a/client/android/project/build.gradle
+++ b/client/android/project/build.gradle
@@ -76,7 +76,7 @@ bintray {
 install {
     repositories.mavenInstaller {
         pom.project {
-            name 'Catbag/Switchboard forked from KeepSafe/Switchboard'
+            name project.name
             description 'A fork from KeepSafe/Switchboard: an project for making A/B Testing'
             url 'https://github.com/Catbag/Switchboard'
             inceptionYear '2012'


### PR DESCRIPTION
Agora é necessário definir o atributo name com o nome do projeto para que o upload do pom seja feito. 
